### PR TITLE
feat: allow multiple metadata file uploads

### DIFF
--- a/invenio_bulk_importer/records/api.py
+++ b/invenio_bulk_importer/records/api.py
@@ -148,7 +148,8 @@ class ImporterTask(Record):
         """
         record_model_class = self.child_record_model_cls
         query = db.session.query(record_model_class.id).filter(
-            record_model_class.task_id == str(self.id)
+            record_model_class.task_id == str(self.id),
+            record_model_class.is_deleted.is_(False),
         )
         return [str(id) for (id,) in query.all()]
 

--- a/invenio_bulk_importer/resources/config.py
+++ b/invenio_bulk_importer/resources/config.py
@@ -9,7 +9,6 @@
 
 import marshmallow as ma
 from flask_resources import (
-    BaseObjectSchema,
     HTTPJSONException,
     JSONSerializer,
     ResponseHandler,

--- a/invenio_bulk_importer/services/components.py
+++ b/invenio_bulk_importer/services/components.py
@@ -7,7 +7,10 @@
 #
 
 """Importer task service components."""
+
 from invenio_records_resources.services.records.components import ServiceComponent
+
+from ..proxies import current_importer_records_service
 
 
 class ImporterTaskServiceComponent(ServiceComponent):
@@ -17,6 +20,13 @@ class ImporterTaskServiceComponent(ServiceComponent):
     def create(self, identity, *, record, **kwargs):
         """Create a new importer task."""
         record.update_start_by_id(identity.user.id)
+
+    def metadata_file_update(self, identity, *, id_, record, **kwargs):
+        """Clean previous tasks to avoid duplicates after uploading a metadata file."""
+        for importer_record_id in record.get_records():
+            current_importer_records_service.delete(
+                identity, id_=importer_record_id, uow=self.uow
+            )
 
 
 class ImporterRecordServiceComponent(ServiceComponent):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1081,7 +1081,7 @@ def task(running_app, user_admin, minimal_importer_task, app_config):
     # Add other files needed for records to be created
     content = BytesIO(b"test file content")
     result = importer_tasks_service._update_file(
-        user_admin.identity, r.id, content, "article", ".txt"
+        user_admin.identity, r._record, content, "article", ".txt"
     )
     assert result.to_dict()["key"] == "article.txt"
     ImporterTask.index.refresh()

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -84,7 +84,7 @@ def _create_task_with_csv_updates(
     # Add other files needed for records to be created
     content = BytesIO(b"test file content")
     result = importer_tasks_service._update_file(
-        identity, task.id, content, "article", ".txt"
+        identity, task._record, content, "article", ".txt"
     )
     assert result.to_dict()["key"] == "article.txt"
     ImporterTask.index.refresh()


### PR DESCRIPTION
* It marks as deleted previous `ImportedRecords` effectively replacing them with the new ones coming from the newly upload file.