### PR TITLE
fix(serializers): add funding to CSV serializer

### DIFF
--- a/invenio_bulk_importer/serializers/records/csv.py
+++ b/invenio_bulk_importer/serializers/records/csv.py
@@ -95,6 +95,12 @@ class Affiliation(BaseModel):
     id: str | None = Field(default=None)
     name: str | None = Field(default=None)
 
+    @model_validator(mode="after")
+    def _require_id_or_name(self) -> "Affiliation":
+        if not self.id and not self.name:
+            raise ValueError("Affiliation requires either 'id' or 'name'.")
+        return self
+
 
 class PersonOrOrg(BaseModel):
     """Schema for person or organization."""
@@ -136,6 +142,12 @@ class Funder(BaseModel):
     id: str | None = Field(default=None)
     name: str | None = Field(default=None)
 
+    @model_validator(mode="after")
+    def _require_id_or_name(self) -> "Funder":
+        if not self.id and not self.name:
+            raise ValueError("Funder requires either 'id' or 'name'.")
+        return self
+
 
 class Award(BaseModel):
     """Award schema."""
@@ -146,6 +158,14 @@ class Award(BaseModel):
     acronym: str | None = Field(default=None)
     program: str | None = Field(default=None)
     identifiers: list[BaseIdentifier] | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _require_id_or_number_or_title(self) -> "Award":
+        if not self.id and not (self.number or self.title):
+            raise ValueError(
+                "Award requires either 'id' or either 'number' or 'title'."
+            )
+        return self
 
 
 class Funding(BaseModel):

--- a/invenio_bulk_importer/serializers/records/csv.py
+++ b/invenio_bulk_importer/serializers/records/csv.py
@@ -8,7 +8,6 @@
 
 """CSV serializer for RDM records."""
 
-from dataclasses import field
 from typing import Annotated, Literal, Optional
 
 from flask import current_app
@@ -131,6 +130,31 @@ class Date(BaseModel):
     description: str | None = Field(default=None)
 
 
+class Funder(BaseModel):
+    """Funder schema."""
+
+    id: str | None = Field(default=None)
+    name: str | None = Field(default=None)
+
+
+class Award(BaseModel):
+    """Award schema."""
+
+    id: str | None = Field(default=None)
+    number: str | None = Field(default=None)
+    title: str | None = Field(default=None)
+    acronym: str | None = Field(default=None)
+    program: str | None = Field(default=None)
+    identifiers: list[BaseIdentifier] | None = Field(default=None)
+
+
+class Funding(BaseModel):
+    """Schema for funding."""
+
+    funder: Funder
+    award: Award | None = Field(default=None)
+
+
 class MetadataSchema(BaseModel):
     """Schema for handling metadata fields."""
 
@@ -167,6 +191,7 @@ class MetadataSchema(BaseModel):
     rights: list[dict[str, str | dict[str, str]]] = Field(default_factory=list)
     formats: list[str] = Field(default_factory=list)
     sizes: list[str] = Field(default_factory=list)
+    funding: list[Funding] = Field(default_factory=list)
 
     @field_validator("resource_type", mode="before")
     def validate_resource_type(cls, value):
@@ -406,6 +431,28 @@ class MetadataSchema(BaseModel):
                 }
             )
         values["dates"] = output
+        return values
+
+    @model_validator(mode="before")
+    def load_funding(cls, values):
+        """Load funding by pairing funders with awards by row index.
+
+        Uses ``drop_empty=False`` so a blank line in the awards columns
+        stays positionally aligned with its funder.
+        """
+        funders = process_grouped_fields(values, "funders", drop_empty=False)
+        awards = process_grouped_fields(values, "awards", drop_empty=False)
+
+        output = []
+        for i, funder in enumerate(funders):
+            if all(v is None for v in funder.values()):
+                continue
+            entry = {"funder": funder}
+            award = awards[i] if i < len(awards) else None
+            if award and any(v is not None for v in award.values()):
+                entry["award"] = award
+            output.append(entry)
+        values["funding"] = output
         return values
 
 

--- a/invenio_bulk_importer/serializers/records/utils.py
+++ b/invenio_bulk_importer/serializers/records/utils.py
@@ -55,38 +55,50 @@ def process_grouped_fields_via_column_title(
     return original
 
 
-def process_grouped_fields(original: dict, prefix: str) -> list:
-    """Process grouped fields in the input dictionary.
+def process_grouped_fields(
+    original: dict, prefix: str, drop_empty: bool = True
+) -> list[dict]:
+    r"""Process grouped fields in the input dictionary.
 
-    Args:
-        original (dict): The original dictionary containing grouped fields.
-        prefix (str): The prefix used to identify the grouped fields.
-    Returns:
-        list: A list of dictionaries representing the grouped fields.
+    Columns whose names start with ``<prefix>.`` are expected to contain
+    newline-separated values. Their cells are split and transposed into a
+    list of per-row dictionaries, one entry per line.
+
+    Example::
+
+        original = {
+            "rights.id":    "cc-by-4.0\\ncc-0",
+            "rights.title": "CC BY 4.0\\nCC 0",
+        }
+        process_grouped_fields(original, "rights") == [
+            {"id": "cc-by-4.0", "title": "CC BY 4.0"},
+            {"id": "cc-0",      "title": "CC 0"},
+        ]
+
+    :param original: The dictionary containing grouped fields.
+    :param prefix: The column-name prefix identifying the group.
+    :param drop_empty: If True (default), rows where every value is ``None``
+        are omitted. Set to False when positional alignment with another
+        group must be preserved (e.g. pairing funders with awards).
+    :return: A list of dictionaries, one per row.
     """
-    group_input = {
-        key: value for key, value in original.items() if key.startswith(f"{prefix}.")
+    pfx = f"{prefix}."
+    split = {
+        key[len(pfx) :]: value.split("\n")
+        for key, value in original.items()
+        if key.startswith(pfx)
     }
-    # Get a temporary list of item information for easier working.
-    try:
-        num_items = max(len(value.split("\n")) for value in group_input.values())
-    except Exception:
-        num_items = 0
+    num_items = max((len(v) for v in split.values()), default=0)
 
     output = []
-    keys = group_input.keys()
     for i in range(num_items):
-        item_dict = {}
-        for key in keys:
-            parts = key.split(".")
-            values = group_input[key].split("\n")
-            item_dict[".".join(parts[1:])] = (
-                values[i] if i < len(values) and values[i].strip() else None
-            )
-        # Remove list dict item if all values are None
-        if all(value is None for value in item_dict.values()):
+        item = {
+            subkey: (parts[i].strip() if i < len(parts) and parts[i].strip() else None)
+            for subkey, parts in split.items()
+        }
+        if drop_empty and all(v is None for v in item.values()):
             continue
-        output.append(item_dict)
+        output.append(item)
     return output
 
 

--- a/invenio_bulk_importer/serializers/records/utils.py
+++ b/invenio_bulk_importer/serializers/records/utils.py
@@ -86,7 +86,7 @@ def process_grouped_fields(
     split = {
         key[len(pfx) :]: value.split("\n")
         for key, value in original.items()
-        if key.startswith(pfx)
+        if key.startswith(pfx) and isinstance(value, str)
     }
     num_items = max((len(v) for v in split.values()), default=0)
 

--- a/tests/serializers/data/rdm_records.csv
+++ b/tests/serializers/data/rdm_records.csv
@@ -1,4 +1,4 @@
-filenames,resource_type.id,creators.type,creators.given_name,creators.family_name,creators.name,creators.identifiers.orcid,creators.identifiers.gnd,creators.identifiers.isni,creators.identifiers.ror,creators.role.id,creators.affiliations.id,creators.affiliations.name,title,additional_titles.alternative-title.eng,publication_date,description,additional_descriptions.abstract,additional_descriptions.method.eng,additional_descriptions.notes,rights.id,rights.title,contributors.type,contributors.given_name,contributors.family_name,contributors.name,contributors.identifiers.orcid,contributors.identifiers.gnd,contributors.identifiers.isni,contributors.identifiers.ror,contributors.role.id,contributors.affiliations.id,contributors.affiliations.name,dates.date,dates.type,dates.description,subjects.scheme,subjects.subject,keywords,languages.id,version,publisher,identifiers.identifier,identifiers.scheme,related_identifiers.identifier,related_identifiers.scheme,related_identifiers.relation_type.id,related_identifiers.resource_type.id,references.reference,default_community_slug,collection_slug,doi,locations.lat,locations.lon,locations.place,locations.description,access.files,access.embargo.active,access.embargo.until,access.embargo.reason,imprint.isbn,imprint.place,imprint.edition,imprint.pages,Imprint.series_name,imprint.volume
+filenames,resource_type.id,creators.type,creators.given_name,creators.family_name,creators.name,creators.identifiers.orcid,creators.identifiers.gnd,creators.identifiers.isni,creators.identifiers.ror,creators.role.id,creators.affiliations.id,creators.affiliations.name,title,additional_titles.alternative-title.eng,publication_date,description,additional_descriptions.abstract,additional_descriptions.method.eng,additional_descriptions.notes,rights.id,rights.title,contributors.type,contributors.given_name,contributors.family_name,contributors.name,contributors.identifiers.orcid,contributors.identifiers.gnd,contributors.identifiers.isni,contributors.identifiers.ror,contributors.role.id,contributors.affiliations.id,contributors.affiliations.name,dates.date,dates.type,dates.description,funders.id,awards.id,awards.title,awards.number,subjects.scheme,subjects.subject,keywords,languages.id,version,publisher,identifiers.identifier,identifiers.scheme,related_identifiers.identifier,related_identifiers.scheme,related_identifiers.relation_type.id,related_identifiers.resource_type.id,references.reference,default_community_slug,collection_slug,doi,locations.lat,locations.lon,locations.place,locations.description,access.files,access.embargo.active,access.embargo.until,access.embargo.reason,imprint.isbn,imprint.place,imprint.edition,imprint.pages,Imprint.series_name,imprint.volume
 "treatment.pdf
 image1.png",publication,"personal
 personal
@@ -33,7 +33,15 @@ cc0-4.0","
 New license
 Existing license",personal,Bob,Collins,,0000-0002-5699-3685,,0000 0001 0706 8891,,05dxps055,,Somewhere Press;Everywhere Press,"2020-12-31
 2025-12-31","other
-other",Random test date,MeSH,Abdominal Injuries,custom,eng,1.0.1,Ubiquity Press,10.2307/4146128,doi,"1.11646/zootaxa.5403.1.5
+other",Random test date,"00k4n6c32
+00k4n6c64
+00k4n6c96","00k4n6c32::755021
+
+","
+
+Some award","
+
+100",MeSH,Abdominal Injuries,custom,eng,1.0.1,Ubiquity Press,10.2307/4146128,doi,"1.11646/zootaxa.5403.1.5
 http://zenodo.org/record/10561536
 http://publication.plazi.org/id/FFECFF80FFD08E48FFFC3B76AC0CFF83
 https://sibils.text-analytics.ch/search/collections/plazi/03D587F8FFD18E4FFF6B3C2BADAEFB92

--- a/tests/serializers/test_csv_rdm_record_serializer.py
+++ b/tests/serializers/test_csv_rdm_record_serializer.py
@@ -238,6 +238,29 @@ def test_record_transform_with_custom_fields(running_app, csv_rdm_record):
         },
     ]
 
+    assert metadata["funding"] == [
+        {
+            "funder": {
+                "id": "00k4n6c32",
+            },
+            "award": {"id": "00k4n6c32::755021"},
+        },
+        {
+            "funder": {
+                "id": "00k4n6c64",
+            },
+        },
+        {
+            "award": {
+                "number": "100",
+                "title": "Some award",
+            },
+            "funder": {
+                "id": "00k4n6c96",
+            },
+        },
+    ]
+
 
 def test_schema_without_custom_fields(running_app, csv_rdm_record):
     """Test validation without custom fields to see if it causes an issue."""

--- a/tests/serializers/test_utils.py
+++ b/tests/serializers/test_utils.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 Ubiquity Press.
+#
+# Invenio-Bulk-Importer is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Unit tests for serializer utilities."""
+
+from invenio_bulk_importer.serializers.records.utils import process_grouped_fields
+
+
+def test_basic_transpose():
+    """Newline-separated cells are split into a list of per-row dicts."""
+    original = {
+        "rights.id": "cc-by-4.0\ncc-0",
+        "rights.title": "CC BY 4.0\nCC 0",
+    }
+    assert process_grouped_fields(original, "rights") == [
+        {"id": "cc-by-4.0", "title": "CC BY 4.0"},
+        {"id": "cc-0", "title": "CC 0"},
+    ]
+
+
+def test_prefix_isolation():
+    """Keys without the prefix must be ignored, prefix match must be exact."""
+    original = {
+        "rights.id": "cc-by-4.0",
+        "rightsholder.id": "should not leak",
+        "other": "ignored",
+    }
+    assert process_grouped_fields(original, "rights") == [{"id": "cc-by-4.0"}]
+
+
+def test_empty_input():
+    """No matching keys returns an empty list (no exception)."""
+    assert process_grouped_fields({}, "anything") == []
+    assert process_grouped_fields({"foo": "bar"}, "rights") == []
+
+
+def test_whitespace_is_stripped():
+    """Values are stripped consistently."""
+    original = {"rights.id": "  cc-0  \n  cc-by-4.0  "}
+    assert process_grouped_fields(original, "rights") == [
+        {"id": "cc-0"},
+        {"id": "cc-by-4.0"},
+    ]
+
+
+def test_ragged_columns_pad_with_none():
+    """When columns have unequal line counts, shorter columns pad with None."""
+    original = {
+        "rights.id": "cc-0\ncc-by-4.0\ncc-by-sa",
+        "rights.title": "CC 0\nCC BY 4.0",
+    }
+    assert process_grouped_fields(original, "rights") == [
+        {"id": "cc-0", "title": "CC 0"},
+        {"id": "cc-by-4.0", "title": "CC BY 4.0"},
+        {"id": "cc-by-sa", "title": None},
+    ]
+
+
+def test_drop_empty_true_drops_all_none_rows():
+    """Default drop_empty=True removes rows whose values are all None."""
+    original = {
+        "rights.id": "cc-0\n\ncc-by-4.0",
+        "rights.title": "CC 0\n\nCC BY 4.0",
+    }
+    assert process_grouped_fields(original, "rights") == [
+        {"id": "cc-0", "title": "CC 0"},
+        {"id": "cc-by-4.0", "title": "CC BY 4.0"},
+    ]
+
+
+def test_drop_empty_false_preserves_all_none_rows():
+    """drop_empty=False keeps all-None rows so positional alignment is intact."""
+    original = {
+        "rights.id": "cc-0\n\ncc-by-4.0",
+        "rights.title": "CC 0\n\nCC BY 4.0",
+    }
+    assert process_grouped_fields(original, "rights", drop_empty=False) == [
+        {"id": "cc-0", "title": "CC 0"},
+        {"id": None, "title": None},
+        {"id": "cc-by-4.0", "title": "CC BY 4.0"},
+    ]
+
+
+def test_funders_and_awards_stay_aligned():
+    """Regression: two paired groups must keep row indices in sync.
+
+    When funder at index 0 has no award and funder at index 1 does, the
+    ``drop_empty=False`` flag ensures ``awards[0]`` is an all-None placeholder
+    rather than being dropped (which would shift ``awards[1]`` into position 0
+    and pair the award with the wrong funder).
+    """
+    original = {
+        "funders.id": "funder1\nfunder2",
+        "funders.name": "Name 1\nName 2",
+        "awards.id": "\naward2",
+        "awards.number": "\nN-002",
+    }
+    funders = process_grouped_fields(original, "funders", drop_empty=False)
+    awards = process_grouped_fields(original, "awards", drop_empty=False)
+
+    assert len(funders) == len(awards) == 2
+    assert funders[0] == {"id": "funder1", "name": "Name 1"}
+    assert funders[1] == {"id": "funder2", "name": "Name 2"}
+    # Placeholder for the first funder — no award data.
+    assert awards[0] == {"id": None, "number": None}
+    assert awards[1] == {"id": "award2", "number": "N-002"}
+
+
+def test_nested_subkeys_preserved():
+    """Subkeys after the first dot (e.g. ``identifiers.orcid``) survive intact."""
+    original = {
+        "creators.name": "Alice\nBob",
+        "creators.identifiers.orcid": "0000-0001\n0000-0002",
+    }
+    assert process_grouped_fields(original, "creators") == [
+        {"name": "Alice", "identifiers.orcid": "0000-0001"},
+        {"name": "Bob", "identifiers.orcid": "0000-0002"},
+    ]

--- a/tests/serializers/test_utils.py
+++ b/tests/serializers/test_utils.py
@@ -39,6 +39,15 @@ def test_empty_input():
     assert process_grouped_fields({"foo": "bar"}, "rights") == []
 
 
+def test_non_string_values_are_skipped():
+    """Non-string values (e.g. already-parsed fields) are ignored, not crashed on."""
+    original = {
+        "rights.id": "cc-0",
+        "rights.parsed": ["already", "a", "list"],
+    }
+    assert process_grouped_fields(original, "rights") == [{"id": "cc-0"}]
+
+
 def test_whitespace_is_stripped():
     """Values are stripped consistently."""
     original = {"rights.id": "  cc-0  \n  cc-by-4.0  "}


### PR DESCRIPTION
* The current implementation doesn't support awards.identifiers properly. Been a nested list field, it is not possible to use the current line break approach to separate different values. Future improvements can be made to allow this field.