### PR TITLE
fix(mappings): disable indexing for dynamic data fields in importerrecord

### DIFF
--- a/invenio_bulk_importer/records/mappings/os-v2/importerrecords/importerrecord-v1.0.0.json
+++ b/invenio_bulk_importer/records/mappings/os-v2/importerrecords/importerrecord-v1.0.0.json
@@ -28,11 +28,11 @@
         },
         "src_data": {
           "type": "object",
-          "dynamic": true
+          "enabled": false
         },
         "serializer_data": {
           "type": "object",
-          "dynamic": true
+          "enabled": false
         },
         "transformed_data": {
           "type": "object",


### PR DESCRIPTION
* Prevent Opensearch mapper_parsing_exception errors caused by inconsistent field types across documents typically after input format changes or new formats added. Setting `enabled: false` stores the data in `_source` without indexing it, avoiding type conflicts.